### PR TITLE
Fix removal of viewBox attribute breaking svg on IE

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -4,7 +4,9 @@ const walk = require('walk');
 const process = require('process');
 const path = require('path');
 
-const svgo = new SVGO();
+const svgo = new SVGO({
+  plugins: [{removeViewBox: false}]
+});
 const cwd = process.cwd();
 
 // Resolves with [beforeSize, afterSize]

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -5,7 +5,7 @@ const process = require('process');
 const path = require('path');
 
 const svgo = new SVGO({
-  plugins: [{removeViewBox: false}]
+  plugins: [{ removeViewBox: false }],
 });
 const cwd = process.cwd();
 


### PR DESCRIPTION
By default svgo removes the viewBox attribute. Removing this attribute can break svg scaling on IE, as IE uses the viewBox attribute to determine the aspect ratio of the vector. 

Example of viewBox kept:
![image](https://user-images.githubusercontent.com/8946502/72227847-3b843080-35f5-11ea-9ac7-4095aad9c561.png)

Example of viewBox removed:
![image](https://user-images.githubusercontent.com/8946502/72227857-535bb480-35f5-11ea-9413-4dab6dd3f5ad.png)
