### PR TITLE
Replace console.log with GatsbyJS reporter

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -32,7 +32,7 @@ const optimizeSVG = async svgPath => new Promise((resolve, reject) => {
   });
 });
 
-exports.onPostBuild = async () => new Promise((resolve, reject) => {
+exports.onPostBuild = async ({ reporter }) => new Promise((resolve, reject) => {
   const walker = walk.walk('public');
 
   let allSVGs = [];
@@ -50,15 +50,13 @@ exports.onPostBuild = async () => new Promise((resolve, reject) => {
   walker.on('end', async () => {
     if (allSVGs.length === 0) {
       // Print a warning if no SVGs were found
-      // eslint-disable-next-line no-console
-      console.warn('gatsby-plugin-optimize-svgs: No SVGs found to optimize!');
+      reporter.warn('gatsby-plugin-optimize-svgs: No SVGs found to optimize!');
     } else {
       // Calculate and print some stats
       const stats = await Promise.all(allSVGs.map(optimizeSVG));
       const [beforeSize, afterSize] = stats.reduce(([a, b], [c, d]) => [a + c, b + d], [0, 0]);
 
-      // eslint-disable-next-line no-console
-      console.log(
+      reporter.success(
         `${stats.length} SVGs minified, reducing the total size from ${beforeSize} bytes to ${afterSize} bytes, a reduction of ${(100 * (beforeSize - afterSize) / beforeSize).toFixed(1)}%!`,
       );
     }


### PR DESCRIPTION
Hi @vzhou842 thanks for the useful plugin.

I've removed console.log statements from the code and used gatsby reporter instead, so the logs use the same format.

Cheers!

<img width="896" alt="Screenshot 2021-01-09 at 20 24 28" src="https://user-images.githubusercontent.com/416757/104105724-02ce7400-52a8-11eb-8799-3cdc53e325f4.png">
