### PR TITLE
Bump svgo -> ^2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "optimize"
   ],
   "dependencies": {
-    "svgo": "^1.3.2",
+    "svgo": "^2.0.0",
     "walk": "^2.3.14"
   },
   "devDependencies": {


### PR DESCRIPTION
Consider bumping svgo -> ^2.0.0. SVGO version 1x is no longer supported, and it is related to security vulnerabilities in nth-check.